### PR TITLE
Fixed default appType overriding appType from pkg jsn

### DIFF
--- a/d2-manifest.js
+++ b/d2-manifest.js
@@ -63,7 +63,8 @@ const args = require('minimist')(process.argv.slice(2), {
 const defaultValues = {
     launch_path: 'index.html',
     default_locale: 'en',
-    activities: { dhis: { href: '*' } }
+    activities: { dhis: { href: '*' } },
+    appType: DEFAULT_APP_TYPE
 };
 
 if(args.debug) {
@@ -143,10 +144,7 @@ if(args.type === false) {
     log.debug('App type disabled'.green);
     delete args.manifest.appType;
 } else if(args.type === undefined) {
-    if(manifest.getFieldValue('appType').length == 0) {
-        manifest.setFieldValue('appType', DEFAULT_APP_TYPE);
-        log.debug('App type set to:'.green, manifest.getFieldValue('appType'));
-    } 
+    log.debug('App type not defined'.green);
 } else {
     switch(args.type.toUpperCase()) {
     case '':

--- a/d2-manifest.js
+++ b/d2-manifest.js
@@ -137,6 +137,9 @@ if(args.timestamp) {
 }
 
 if(args.type === false) {
+    if(manifest.getFieldValue('appType').length != 0) {
+        manifest.setFieldValue('appType', '');
+    } 
     log.debug('App type disabled'.green);
     delete args.manifest.appType;
 } else if(args.type === undefined) {

--- a/d2-manifest.js
+++ b/d2-manifest.js
@@ -9,6 +9,8 @@ log.setDefaultLevel(log.levels.INFO);
 
 const Manifest = require('./src/Manifest');
 
+const DEFAULT_APP_TYPE = 'APP';
+
 const args = require('minimist')(process.argv.slice(2), {
     alias: {
         debug: ['!'],
@@ -55,7 +57,6 @@ const args = require('minimist')(process.argv.slice(2), {
     boolean: ['debug', 'help', 'interactive', 'ugly', 'timestamp'],
     default: {
         timestamp: true,
-        'manifest.appType': 'APP'
     }
 });
 
@@ -139,7 +140,10 @@ if(args.type === false) {
     log.debug('App type disabled'.green);
     delete args.manifest.appType;
 } else if(args.type === undefined) {
-    log.debug('App type not defined'.green);
+    if(manifest.getFieldValue('appType').length == 0) {
+        manifest.setFieldValue('appType', DEFAULT_APP_TYPE);
+        log.debug('App type set to:'.green, manifest.getFieldValue('appType'));
+    } 
 } else {
     switch(args.type.toUpperCase()) {
     case '':


### PR DESCRIPTION
Fix for https://github.com/dhis2/d2-manifest/issues/13
1. d2-manifest.js package.json manifest.webapp
i. If package.json does not contain appType - default "appType":"APP" should be written in manifest.
ii. If package.json contain appType, that value should be written in manifest.
1. d2-manifest.js package.json --no-type manifest.webapp :- manifest file should not contain appType irrespective package.json contains appType or not.
2. d2-manifest.js package.json -t DASHBOARD manifest.webapp :- "appType":"DASHBOARD_WIDGET" should be written in manifest irrespective of any value of appType in package.json.
